### PR TITLE
(GH-85) Use extension page on Cake website as projectUrl

### DIFF
--- a/nuspec/nuget/Cake.Markdownlint.nuspec
+++ b/nuspec/nuget/Cake.Markdownlint.nuspec
@@ -11,7 +11,7 @@
 This addin for Cake allows you to lint Markdown files using markdownlint.
     </description>
     <license type="expression">MIT</license>
-    <projectUrl>http://cake-contrib.github.io/Cake.Markdownlint/</projectUrl>
+    <projectUrl>https://cakebuild.net/extensions/cake-markdownlint/</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/cake-contrib/graphics@a5cf0f881c390650144b2243ae551d5b9f836196/png/cake-contrib-medium.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <repository type="git" url="https://github.com/cake-contrib/Cake.Markdownlint.git"/>


### PR DESCRIPTION
Use extension page on Cake website as projectUrl in NuGet package.

Fixes #85 