### PR TITLE
(GH-148) Multi-Target .NET Core 3.1, 5 & 6 instead of .NET Standard 2.0

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,8 +10,9 @@ install:
   - ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnetsdk"
   - ps: mkdir $env:DOTNET_INSTALL_DIR -Force | Out-Null
   - ps: Invoke-WebRequest -Uri "https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.ps1" -OutFile "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1"
-  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 2.1.818 -InstallDir $env:DOTNET_INSTALL_DIR'
+  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 3.1.426 -InstallDir $env:DOTNET_INSTALL_DIR'
   - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 5.0.408 -InstallDir $env:DOTNET_INSTALL_DIR'
+  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 6.0.413 -InstallDir $env:DOTNET_INSTALL_DIR'
   - ps: $env:Path = "$env:DOTNET_INSTALL_DIR;$env:Path"
   - ps: dotnet --info
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,13 +16,17 @@ jobs:
   steps:
   - task: UseDotNet@2
     inputs:
-      version: '2.1.x'
-    displayName: 'Install .NET Core 2.1'
+      version: '3.1.x'
+    displayName: 'Install .NET Core 3.1'
   # .NET 5 required for GitVersion
   - task: UseDotNet@2
     inputs:
       version: '5.x'
     displayName: 'Install .NET 5'
+  - task: UseDotNet@2
+    inputs:
+      version: '6.x'
+    displayName: 'Install .NET 6'
   - powershell: |
       $ENV:CAKE_SKIP_GITVERSION=([string]::IsNullOrEmpty($ENV:SYSTEM_PULLREQUEST_PULLREQUESTID) -eq $False).ToString()
       .\build.ps1
@@ -34,13 +38,17 @@ jobs:
   steps:
   - task: UseDotNet@2
     inputs:
-      version: '2.1.x'
-    displayName: 'Install .NET Core 2.1'
+      version: '3.1.x'
+    displayName: 'Install .NET Core 3.1'
   # .NET 5 required for GitVersion
   - task: UseDotNet@2
     inputs:
       version: '5.x'
     displayName: 'Install .NET 5'
+  - task: UseDotNet@2
+    inputs:
+      version: '6.x'
+    displayName: 'Install .NET 6'
   - bash: |
       ./build.sh
     displayName: 'Cake Build'
@@ -50,13 +58,17 @@ jobs:
   steps:
   - task: UseDotNet@2
     inputs:
-      version: '2.1.x'
-    displayName: 'Install .NET Core 2.1'
+      version: '3.1.x'
+    displayName: 'Install .NET Core 3.1'
   # .NET 5 required for GitVersion
   - task: UseDotNet@2
     inputs:
       version: '5.x'
     displayName: 'Install .NET 5'
+  - task: UseDotNet@2
+    inputs:
+      version: '6.x'
+    displayName: 'Install .NET 6'
   - bash: |
       ./build.sh --verbosity diagnostic
     displayName: 'Cake Build'

--- a/nuspec/nuget/Cake.Markdownlint.nuspec
+++ b/nuspec/nuget/Cake.Markdownlint.nuspec
@@ -21,8 +21,14 @@ This addin for Cake allows you to lint Markdown files using markdownlint.
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="netstandard2.0\Cake.Markdownlint.dll" target="lib\netstandard2.0" />
-    <file src="netstandard2.0\Cake.Markdownlint.pdb" target="lib\netstandard2.0" />
-    <file src="netstandard2.0\Cake.Markdownlint.xml" target="lib\netstandard2.0" />
+    <file src="netcoreapp3.1\Cake.Markdownlint.dll" target="lib\netcoreapp3.1" />
+    <file src="netcoreapp3.1\Cake.Markdownlint.pdb" target="lib\netcoreapp3.1" />
+    <file src="netcoreapp3.1\Cake.Markdownlint.xml" target="lib\netcoreapp3.1" />
+    <file src="net5.0\Cake.Markdownlint.dll" target="lib\net5.0" />
+    <file src="net5.0\Cake.Markdownlint.pdb" target="lib\net5.0" />
+    <file src="net5.0\Cake.Markdownlint.xml" target="lib\net5.0" />
+    <file src="net6.0\Cake.Markdownlint.dll" target="lib\net6.0" />
+    <file src="net6.0\Cake.Markdownlint.pdb" target="lib\net6.0" />
+    <file src="net6.0\Cake.Markdownlint.xml" target="lib\net6.0" />
   </files>
 </package>

--- a/src/Cake.Markdownlint.Tests/Cake.Markdownlint.Tests.csproj
+++ b/src/Cake.Markdownlint.Tests/Cake.Markdownlint.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <Product>Cake.Markdownlint</Product>
     <Copyright>Copyright © BBT Software AG and contributors</Copyright>

--- a/src/Cake.Markdownlint/Cake.Markdownlint.csproj
+++ b/src/Cake.Markdownlint/Cake.Markdownlint.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <Description>Addin for the Cake build automation system for running linting on Markdown files</Description>
     <Authors>BBT Software AG</Authors>
     <Company>BBT Software AG</Company>
@@ -9,18 +9,11 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Cake.Markdownlint.xml</DocumentationFile>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>..\Cake.Markdownlint.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
-    <DocumentationFile>bin\Debug\netstandard2.0\Cake.Markdownlint.xml</DocumentationFile>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard2.0\Cake.Markdownlint.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Multi-Targets .NET Core 3.1, 5 & 6 instead of .NET Standard 2.0

Fixes #148 