### PR TITLE
Remove no longer required Cake configuration file

### DIFF
--- a/cake.config
+++ b/cake.config
@@ -1,3 +1,0 @@
-[Nuget]
-; Use the new InProcess client, because some packages have long file paths.
-UseInProcessClient=true 


### PR DESCRIPTION
Removes configuration file which is no longer required since Cake .NET tool is used